### PR TITLE
Unifying postgres to postgresql

### DIFF
--- a/datasource/event-booking/README.md
+++ b/datasource/event-booking/README.md
@@ -91,7 +91,7 @@ Run the integration directly with Camel JBang:
 ```bash
 camel run book.camel.yaml forage-datasource-factory.properties \
   --dep=mvn:org.apache.camel.forage:forage-jdbc:1.0-SNAPSHOT \
-  --dep=mvn:org.apache.camel.forage:forage-jdbc-postgres:1.0-SNAPSHOT
+  --dep=mvn:org.apache.camel.forage:forage-jdbc-postgresql:1.0-SNAPSHOT
 ```
 
 ### Option 2: Spring Boot Export
@@ -101,7 +101,7 @@ Export the integration as a Spring Boot application:
 ```bash
 camel export book.camel.yaml forage-datasource-factory.properties \
   --dep=mvn:org.apache.camel.forage:forage-jdbc-starter:1.0-SNAPSHOT \
-  --dep=mvn:org.apache.camel.forage:forage-jdbc-postgres:1.0-SNAPSHOT \
+  --dep=mvn:org.apache.camel.forage:forage-jdbc-postgresql:1.0-SNAPSHOT \
   --runtime=spring-boot
 ```
 

--- a/datasource/event-booking/forage-datasource-factory.properties
+++ b/datasource/event-booking/forage-datasource-factory.properties
@@ -3,7 +3,7 @@
 jdbc.url=jdbc:postgresql://localhost:5432/postgres
 jdbc.username=test
 jdbc.password=test
-jdbc.db.kind=postgres
+jdbc.db.kind=postgresql
 
 # Connection pool settings
 jdbc.pool.initial.size=5

--- a/datasource/multi/Route.java
+++ b/datasource/multi/Route.java
@@ -6,14 +6,14 @@ public class Route extends RouteBuilder {
     public void configure() throws Exception {
         from("timer:java?period=1000")
                 .to("sql:select * from bar?dataSource=#ds1")
-                .log("from sql postgres - ${body}")
+                .log("from sql postgresql - ${body}")
                 .to("sql:select * from test.foo?dataSource=#ds2")
                 .log("from sql mysql - ${body}");
 
         from("timer:java?period=1000")
                 .setBody(constant("select * from bar"))
                 .to("jdbc:ds1")
-                .log("from jdbc postgres - ${body}")
+                .log("from jdbc postgresql - ${body}")
                 .setBody(constant("select * from test.foo"))
                 .to("jdbc:ds2")
                 .log("from jdbc mysql - ${body}");
@@ -21,7 +21,7 @@ public class Route extends RouteBuilder {
         from("timer:java?period=1000")
                 .setBody(constant("select * from bar"))
                 .to("spring-jdbc:ds1")
-                .log("from spring jdbc postgres - ${body}")
+                .log("from spring jdbc postgresql - ${body}")
                 .setBody(constant("select * from test.foo"))
                 .to("spring-jdbc:ds2")
                 .log("from spring jdbc mysql - ${body}");

--- a/datasource/multi/forage-datasource-factory.properties
+++ b/datasource/multi/forage-datasource-factory.properties
@@ -1,6 +1,6 @@
 # PostgreSQL JDBC Configuration
 # Database connection settings
-ds1.jdbc.db.kind=postgres
+ds1.jdbc.db.kind=postgresql
 ds1.jdbc.url=jdbc:postgresql://localhost:5432/postgres
 ds1.jdbc.username=test
 ds1.jdbc.password=test

--- a/datasource/multi/route.camel.yaml
+++ b/datasource/multi/route.camel.yaml
@@ -15,7 +15,7 @@
               query: select * from bar
         - log:
             id: log-2176
-            message: from sql postgres ds - ${body}
+            message: from sql postgresql ds - ${body}
         - to:
             id: to-1832
             uri: sql
@@ -45,7 +45,7 @@
               dataSourceName: ds1
         - log:
             id: log-2176-3777
-            message: from jdbc postgres - ${body}
+            message: from jdbc postgresql - ${body}
         - setBody:
             id: setBody-2643
             simple:
@@ -78,7 +78,7 @@
               dataSourceName: ds1
         - log:
             id: log-2176-3777-4035
-            message: from jdbc postgres - ${body}
+            message: from jdbc postgresql - ${body}
         - setBody:
             id: setBody-2643-3720
             simple:

--- a/datasource/single/forage-datasource-factory.properties
+++ b/datasource/single/forage-datasource-factory.properties
@@ -4,7 +4,6 @@ jdbc.db.kind=postgresql
 jdbc.url=jdbc:postgresql://localhost:5432/postgres
 jdbc.username=test
 jdbc.password=test
-jdbc.db.kind=postgres
 
 # Connection pool settings
 jdbc.pool.initial.size=5


### PR DESCRIPTION
Using only postgresql (not postgres) accros the forage-examples.

@Croway As I was manually checking the examples after this refactor,. I noticed that `event-booking` demo (when running on runtimes `main`  or `spring-boot` is not rollbackling  -> works on `quarkus`, therefore I think there might be a problem woth some bean configuration.